### PR TITLE
Allow caller to control SSL setup and don't delete DELETE data

### DIFF
--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -34,7 +34,7 @@ Net::Proxmox::VE - Pure perl API for Proxmox virtualisation
     %args = (
         host     => 'proxmox.local.domain',
         password => 'barpassword',
-        user     => 'root', # optional
+        username => 'root', # optional
         port     => 8006,   # optional
         realm    => 'pam',  # optional
     );

--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -41,7 +41,7 @@ Net::Proxmox::VE - Pure perl API for Proxmox virtualisation
 
     $host = Net::Proxmox::VE->new(%args);
 
-    $host->login() or die ('Couldnt log in to proxmox host');
+    $host->login() or die ('Couldn\'t log in to proxmox host');
 
 =head1 WARNING
 

--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -316,6 +316,28 @@ TCP port number used to by the Proxmox host instance. Defaults to 8006, optional
 
 Authentication realm to request against. Defaults to 'pam' (local auth), optional.
 
+=item I<ssl_opts>
+
+If you're using a self-signed certificate, SSL verification is going to fail, and we need to tell C<IO::Socket::SSL> not to attempt certificate verification.
+
+This option is passed on as C<ssl_opts> options to C<LWP::UserAgent-E<gt>new()>, ultimately for C<IO::Socket::SSL>.
+
+Using it like this, causes C<LWP::UserAgent> and C<IO::Socket::SSL> not to attempt SSL verification:
+
+    use IO::Socket::SSL qw(SSL_VERIFY_NONE);
+    ..
+    %args = (
+        ...
+        ssl_opts => {
+            SSL_verify_mode => SSL_VERIFY_NONE,
+            verify_hostname => 0
+        },
+        ...
+    );
+    my $proxmox = Net::Proxmox::VE->new(%args);
+
+Your connection will work now, but B<beware: you are now susceptible to a man-in-the-middle attack>.
+
 =item I<debug>
 
 Enabling debugging of this API (not related to proxmox debugging in any way). Defaults to false, optional.

--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -157,12 +157,6 @@ sub action {
         my $content = $response->decoded_content;
         my $data    = decode_json( $response->decoded_content );
 
-        # DELETE operations return no data
-        # otherwise if we have a data key but its empty, treat it as a failure
-        if ( $params{method} eq 'DELETE' ) {
-            return 1;
-        }
-
         if ( ref $data eq 'HASH'
             && exists $data->{data} )
         {

--- a/lib/Net/Proxmox/VE/Access.pm
+++ b/lib/Net/Proxmox/VE/Access.pm
@@ -859,7 +859,12 @@ sub login {
     # Prepare login request
     my $url = $self->url_prefix . '/api2/json/access/ticket';
 
-    my $ua = LWP::UserAgent->new( ssl_opts => { verify_hostname => undef } );
+    my %lwpUserAgentOptions;
+    if ($self->{params}->{ssl_opts}) {
+        $lwpUserAgentOptions{ssl_opts} = $self->{params}->{ssl_opts};
+    }
+
+    my $ua = LWP::UserAgent->new( %lwpUserAgentOptions );
 
     $ua->timeout($self->{params}->{timeout});
 


### PR DESCRIPTION
Hi,

4 commits:

1) Delete operation data was simply discarded for no reason I could find. I needed the delete results
2) Don't hard code verify_hostname => undef. Allow user to do that and don't hard code something unsafe.
3 + 4) Minor spelling mistakes in perldoc.

Peter