### PR TITLE
PUT patch removed

### DIFF
--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -139,7 +139,7 @@ sub action {
 # an unrecognised method
 # so we'll just force POST from PUT
     if ( $params{method} =~ m/^(PUT|POST)$/ ) {
-        $request->method('POST');
+        $request->method( $params{method} );    # Patch removed
         my $content = join '&', map { $_ . '=' . $params{post_data}->{$_} }
           sort keys %{ $params{post_data} };
         $request->content($content);


### PR DESCRIPTION
Now PUT is documented (http://pve.proxmox.com/pve2-api-doc/) and some API calls only accepts this method (/access/acl for example).
I think developer MUST know API specifications and use its methods accordingly, so this patch is not needed anymore.