### PR TITLE
Replace the print statements in action with die

### DIFF
--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -187,8 +187,8 @@ sub action {
 
     }
     else {
-        print "WARNING: request failed: " . $request->as_string . "\n";
-        print "WARNING: response status: " . $response->status_line . "\n";
+        die "WARNING: request failed: "  . $request->as_string . "\n" .
+            "WARNING: response status: " . $response->status_line . "\n";
     }
     return
 


### PR DESCRIPTION
This replaces the two print statements in `action` with a die instead, fixing #7 