### PR TITLE
Fix sub debug, set correct flag

### DIFF
--- a/lib/Net/Proxmox/VE.pm
+++ b/lib/Net/Proxmox/VE.pm
@@ -236,13 +236,13 @@ sub debug {
     my $d = shift;
 
     if ($d) {
-        $self->{debug} = 1;
+        $self->{params}->{debug} = 1;
     }
     elsif ( defined $d ) {
-        $self->{debug} = 0;
+        $self->{params}->{debug} = 0;
     }
 
-    return 1 if $self->{debug};
+    return 1 if $self->{params}->{debug};
     return
 
 }


### PR DESCRIPTION
Sub debug manipulates $self->{debug}, but this is wrong. It should be $self->{params}->{debug}.