### PR TITLE
fix/use correct parameter name for user in tests

### DIFF
--- a/t/101-proxmox-ve-new.t
+++ b/t/101-proxmox-ve-new.t
@@ -53,7 +53,7 @@ Try something like...
         $obj = Net::Proxmox::VE->new(
             host     => $host,
             password => $pass,
-            user     => $user,
+            username => $user,
             port     => $port,
             realm    => $realm,
             ssl_opts => {

--- a/t/120-proxmox-ve-access.t
+++ b/t/120-proxmox-ve-access.t
@@ -39,7 +39,7 @@ Try something like...
         $obj = Net::Proxmox::VE->new(
             host     => $host,
             password => $pass,
-            user     => $user,
+            username => $user,
             port     => $port,
             realm    => $realm,
             ssl_opts => {


### PR DESCRIPTION
The tests used 'user' instead of the correct username, thus defaulting to the root user instead of the one that was passed.